### PR TITLE
PR3: Navigation Hierarchy + Hero Metrics Row

### DIFF
--- a/src/screens/dashboard/components/hero-metrics-row.tsx
+++ b/src/screens/dashboard/components/hero-metrics-row.tsx
@@ -1,0 +1,96 @@
+import {
+  Activity01Icon,
+  AiChipIcon,
+  ChartLineData02Icon,
+  Timer02Icon,
+} from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
+import type { DashboardIcon } from './dashboard-types'
+
+type HeroMetric = {
+  label: string
+  value: string
+  icon: DashboardIcon
+  accent?: 'green' | 'amber' | 'blue' | 'default'
+}
+
+type HeroMetricsRowProps = {
+  currentModel: string
+  uptimeSeconds: number
+  sessionCount: number
+  totalSpend: string
+  gatewayConnected: boolean
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds <= 0) return '—'
+  const days = Math.floor(seconds / 86400)
+  const hours = Math.floor((seconds % 86400) / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  if (days > 0) return `${days}d ${hours}h`
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+const accentColors = {
+  green: 'border-emerald-200 bg-emerald-50/60',
+  amber: 'border-amber-200 bg-amber-50/60',
+  blue: 'border-blue-200 bg-blue-50/60',
+  default: 'border-primary-200 bg-primary-50/60',
+} as const
+
+export function HeroMetricsRow({
+  currentModel,
+  uptimeSeconds,
+  sessionCount,
+  totalSpend,
+  gatewayConnected,
+}: HeroMetricsRowProps) {
+  const metrics: HeroMetric[] = [
+    {
+      label: 'Current Model',
+      value: currentModel || '—',
+      icon: AiChipIcon,
+      accent: 'blue',
+    },
+    {
+      label: 'Sessions',
+      value: `${sessionCount}`,
+      icon: Activity01Icon,
+      accent: gatewayConnected ? 'green' : 'default',
+    },
+    {
+      label: 'Uptime',
+      value: formatUptime(uptimeSeconds),
+      icon: Timer02Icon,
+      accent: 'default',
+    },
+    {
+      label: 'Period Spend',
+      value: totalSpend,
+      icon: ChartLineData02Icon,
+      accent: 'amber',
+    },
+  ]
+
+  return (
+    <div className="mb-4 grid grid-cols-2 gap-2.5 md:grid-cols-4">
+      {metrics.map((m) => (
+        <div
+          key={m.label}
+          className={`flex items-center gap-3 rounded-xl border p-3 backdrop-blur-sm transition-colors ${accentColors[m.accent ?? 'default']}`}
+        >
+          <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg border border-primary-200/50 bg-white/70 text-primary-600">
+            <HugeiconsIcon icon={m.icon} size={16} strokeWidth={1.5} />
+          </span>
+          <div className="min-w-0">
+            <p className="truncate text-lg font-semibold tabular-nums text-ink leading-tight">
+              {m.value}
+            </p>
+            <p className="text-[11px] text-primary-500 leading-tight">{m.label}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/screens/dashboard/constants/grid-config.ts
+++ b/src/screens/dashboard/constants/grid-config.ts
@@ -52,8 +52,6 @@ export const SIZE_TIERS: Record<WidgetSizeTier, TierDimensions> = {
 
 /* ── Widget Registry ── */
 export type WidgetId =
-  | 'weather'
-  | 'quick-actions'
   | 'time-date'
   | 'usage-meter'
   | 'tasks'
@@ -63,6 +61,7 @@ export type WidgetId =
   | 'system-status'
   | 'notifications'
   | 'activity-log'
+  | 'weather'
 
 type WidgetRegistryEntry = {
   id: WidgetId
@@ -72,17 +71,20 @@ type WidgetRegistryEntry = {
 }
 
 export const WIDGET_REGISTRY: WidgetRegistryEntry[] = [
-  { id: 'weather', defaultTier: 'S', allowedTiers: ['S'] },
-  { id: 'quick-actions', defaultTier: 'XL', allowedTiers: ['XL', 'L'] },
+  // Row 1: Time + System Status + Activity Log (3 small)
   { id: 'time-date', defaultTier: 'S', allowedTiers: ['S'] },
-  { id: 'usage-meter', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  { id: 'tasks', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  { id: 'agent-status', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  { id: 'cost-tracker', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  { id: 'recent-sessions', defaultTier: 'L', allowedTiers: ['L', 'M'] },
   { id: 'system-status', defaultTier: 'S', allowedTiers: ['S', 'M'] },
-  { id: 'notifications', defaultTier: 'L', allowedTiers: ['L', 'M'] },
   { id: 'activity-log', defaultTier: 'S', allowedTiers: ['S', 'M'] },
+  // Row 2-3: Main data widgets (medium)
+  { id: 'usage-meter', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  { id: 'cost-tracker', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  { id: 'agent-status', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  { id: 'tasks', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  // Row 4: Sessions + Notifications (large)
+  { id: 'recent-sessions', defaultTier: 'L', allowedTiers: ['L', 'M'] },
+  { id: 'notifications', defaultTier: 'L', allowedTiers: ['L', 'M'] },
+  // Bottom: Weather (nice-to-have)
+  { id: 'weather', defaultTier: 'S', allowedTiers: ['S'] },
 ]
 
 /* ── Layout Constraints ── */


### PR DESCRIPTION
## Changes
- **Hero Metrics Row**: 4 compact stat cards (Current Model, Sessions, Uptime, Period Spend) wired to live gateway data
- **Persistent Quick Actions**: Moved from draggable grid widget to always-visible header buttons
- **Weather below fold**: Reordered to bottom of grid registry
- **Icon fix**: Uses `AiChipIcon` for model metric (valid hugeicons export)

## Files Changed (3)
- `hero-metrics-row.tsx` (NEW) — hero metrics component
- `grid-config.ts` — removed quick-actions, reordered weather
- `dashboard-screen.tsx` — header Quick Actions + HeroMetricsRow integration

## Testing
1. `npm run build` passes
2. Dashboard shows hero row between header and grid
3. Quick Actions are always visible in header (not draggable)
4. Weather widget renders at bottom of grid

Depends on: PR #9