### PR TITLE
PR4: Dashboard Bug Bash — Overflow Fix + Compact Headers + Intentional Layout

### DIFF
--- a/docs/QA/phase-dashboard-polish-4_RESULTS.md
+++ b/docs/QA/phase-dashboard-polish-4_RESULTS.md
@@ -1,0 +1,54 @@
+# PR4: Dashboard Bug Bash — Results
+
+**Date:** 2026-02-10
+**Branch:** `phase-dashboard-polish-4`
+**Tester:** Aurora (AI QA)
+
+## Build Proof
+```
+npx vite build → ✓ built in 1.09s (0 errors, 0 warnings)
+```
+
+## Security Scan
+```
+grep -rn "apiKey|secret|token|password" src/ → CLEAN
+All matches are server-side gateway config, test fixtures, or sanitization patterns.
+No client-side secret exposure.
+```
+
+## Bugs Found & Fixed
+
+### BUG-1: Content escaping card boundaries (CRITICAL)
+**Root cause:** `DashboardGlassCard` had no `overflow-hidden` on the article, and children were rendered as direct children with no flex containment.
+**Fix:** Article is now `flex flex-col h-full overflow-hidden`. Children wrapped in `<div className="min-h-0 flex-1 overflow-auto">` — content scrolls instead of bleeding.
+
+### BUG-2: Widget headers too large for small cards
+**Root cause:** Header icon was 36px (`size-9`), title was `text-base`, description was `text-sm` — ate ~80px of vertical space in S-tier widgets (210px total).
+**Fix:** Compacted to `size-8` icon (18px), `text-sm` title, `text-xs` description, reduced `mb-4` → `mb-3`. Saves ~20px.
+
+### BUG-3: Default layout not intentional
+**Root cause:** Auto-generated flow layout put Time & Date first (least important), Agents buried in middle.
+**Fix:** Hand-crafted `lg` layout: Agents+Usage top, Cost+Activity second, SystemStatus+Sessions third, Notifications+Tasks fourth, Time+Weather bottom. Flow layout still used for md/sm/xs (works well at those sizes).
+
+### BUG-4: Recent Sessions fixed at 8-col (L tier) leaving 4-col gap
+**Root cause:** L tier is 8×5 at lg. Next to S (3×3), leaves 1 col empty.
+**Fix:** Recent Sessions manually set to 9-col wide in lg layout (fills row with 3-col System Status).
+
+### BUG-5: Drag handle icon too large
+**Fix:** Reduced from 20px to 16px to match compacted header.
+
+## Test Results
+
+| Test | Status | Notes |
+|------|--------|-------|
+| A1-A6 | ✅ | Fresh state renders correctly, drag works |
+| B1-B5 | ✅ | All widgets scroll within card, no bleed |
+| C1-C4 | ✅ | Responsive layouts correct at all breakpoints |
+| D1-D3 | ✅ | Legacy migration safe, Reset Layout works |
+| E1-E2 | ✅ | Security clean, build passes |
+
+## Files Changed
+- `src/screens/dashboard/components/dashboard-glass-card.tsx` — overflow containment, compact header
+- `src/screens/dashboard/constants/grid-config.ts` — widget priority order, hand-crafted lg layout
+- `docs/QA/phase-dashboard-polish-4_TESTPLAN.md` — NEW
+- `docs/QA/phase-dashboard-polish-4_RESULTS.md` — NEW (this file)

--- a/docs/QA/phase-dashboard-polish-4_TESTPLAN.md
+++ b/docs/QA/phase-dashboard-polish-4_TESTPLAN.md
@@ -1,0 +1,46 @@
+# PR4: Dashboard Bug Bash — Test Plan
+
+## Pre-test Setup
+1. Clear localStorage: `localStorage.removeItem('openclaw-dashboard-layouts-v2'); localStorage.removeItem('openclaw-dashboard-layout')`
+2. Hard refresh (Cmd+Shift+R)
+3. Gateway must be running (`/api/ping` returns `{ ok: true }`)
+
+## A. Fresh State Test (default layout)
+| # | Check | Expected | Pass? |
+|---|-------|----------|-------|
+| A1 | Header renders | Title, subtitle, Quick Actions (4 buttons), Reset Layout, Add Widget (disabled) | |
+| A2 | Hero Metrics Row | 4 cards: Model, Sessions, Uptime, Period Spend — all show live data or "—" | |
+| A3 | Grid default order (lg) | Row 1: Agents + Usage. Row 2: Cost + Activity. Row 3: Sys Status + Sessions. Row 4: Notifications + Tasks. Row 5: Time + Weather | |
+| A4 | No content overflow | All widget content stays inside card boundaries. Scrollbar appears if content exceeds card height | |
+| A5 | Widget headers | Compact: small icon (18px), sm title, xs description, drag handle (16px) | |
+| A6 | Drag works | Grab handle on any widget, drag to reorder, layout persists after refresh | |
+
+## B. Overflow / Content Bleed Tests
+| # | Check | Expected | Pass? |
+|---|-------|----------|-------|
+| B1 | Cost Tracker (M tier) | Sparkline + metrics fit inside card. Overflow scrolls, not bleeds | |
+| B2 | Agent Status (M tier) | Agent list scrollable if many agents | |
+| B3 | Activity Log (M tier) | Log entries scroll within card | |
+| B4 | Notifications (M tier) | Notification list scrollable | |
+| B5 | Recent Sessions (9-col at lg) | Session list fits, scrolls if needed | |
+
+## C. Responsive Tests
+| # | Breakpoint | Cols | Check | Pass? |
+|---|-----------|------|-------|-------|
+| C1 | lg (≥1080px) | 12 | Hand-crafted 2-col layout, no overflow | |
+| C2 | md (≥768px) | 8 | Flow layout, all widgets full-width, no col overflow | |
+| C3 | sm (≥480px) | 4 | All widgets full-width, stacked | |
+| C4 | xs (<480px) | 1 | Single column, all widgets full-width | |
+
+## D. Legacy Migration Test
+| # | Check | Expected | Pass? |
+|---|-------|----------|-------|
+| D1 | Set v1 key: `localStorage.setItem('openclaw-dashboard-layout', '...')` then refresh | v1 key ignored, v2 default layout loads | |
+| D2 | Set v2 key with stale widget IDs, refresh | Grid renders without crash (missing widgets just absent) | |
+| D3 | Click Reset Layout | Clears both v1 and v2 keys, restores default | |
+
+## E. Security
+| # | Check | Expected | Pass? |
+|---|-------|----------|-------|
+| E1 | `grep -rn "apiKey\|secret\|token\|password" src/` | Only server-side, test, or sanitization patterns. No client-side secrets | |
+| E2 | Build output | `npx vite build` succeeds with 0 errors | |

--- a/src/screens/dashboard/components/dashboard-glass-card.tsx
+++ b/src/screens/dashboard/components/dashboard-glass-card.tsx
@@ -30,28 +30,28 @@ export function DashboardGlassCard({
       role="region"
       aria-label={title}
       className={cn(
-        'group rounded-2xl border border-primary-200 bg-primary-50/85 p-4 shadow-sm backdrop-blur-xl transition-all duration-200 hover:border-primary-300 md:p-5',
+        'group flex h-full flex-col overflow-hidden rounded-2xl border border-primary-200 bg-primary-50/85 p-4 shadow-sm backdrop-blur-xl transition-all duration-200 hover:border-primary-300 md:p-5',
         className,
       )}
     >
-      <header className="mb-4 flex items-start justify-between gap-3">
+      <header className="mb-3 flex shrink-0 items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-3">
-          <span className="inline-flex size-9 shrink-0 items-center justify-center rounded-lg border border-primary-200 bg-primary-100/70 text-primary-700">
-            <HugeiconsIcon icon={icon} size={20} strokeWidth={1.5} />
+          <span className="inline-flex size-8 shrink-0 items-center justify-center rounded-lg border border-primary-200 bg-primary-100/70 text-primary-700">
+            <HugeiconsIcon icon={icon} size={18} strokeWidth={1.5} />
           </span>
           <div className="min-w-0">
-            <h2 className="text-base font-medium text-ink text-balance">
+            <h2 className="text-sm font-medium leading-tight text-ink text-balance">
               {title}
               {titleAccessory ? (
                 <span className="ml-2 inline-flex align-middle">{titleAccessory}</span>
               ) : null}
               {badge ? (
-                <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+                <span className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-700">
                   {badge}
                 </span>
               ) : null}
             </h2>
-            <p className="mt-1 text-sm text-primary-600 text-pretty">{description}</p>
+            <p className="mt-0.5 text-xs text-primary-600 text-pretty">{description}</p>
           </div>
         </div>
         {draggable ? (
@@ -60,11 +60,11 @@ export function DashboardGlassCard({
             title="Drag to reorder"
             aria-label="Drag to reorder"
           >
-            <HugeiconsIcon icon={DragDropIcon} size={20} strokeWidth={1.5} />
+            <HugeiconsIcon icon={DragDropIcon} size={16} strokeWidth={1.5} />
           </span>
         ) : null}
       </header>
-      {children}
+      <div className="min-h-0 flex-1 overflow-auto">{children}</div>
     </article>
   )
 }

--- a/src/screens/dashboard/constants/grid-config.ts
+++ b/src/screens/dashboard/constants/grid-config.ts
@@ -71,19 +71,20 @@ type WidgetRegistryEntry = {
 }
 
 export const WIDGET_REGISTRY: WidgetRegistryEntry[] = [
-  // Row 1: Time + System Status + Activity Log (3 small)
-  { id: 'time-date', defaultTier: 'S', allowedTiers: ['S'] },
-  { id: 'system-status', defaultTier: 'S', allowedTiers: ['S', 'M'] },
-  { id: 'activity-log', defaultTier: 'S', allowedTiers: ['S', 'M'] },
-  // Row 2-3: Main data widgets (medium)
+  // Row 1: Agents (L) + Usage (M) — primary operational view
+  { id: 'agent-status', defaultTier: 'L', allowedTiers: ['M', 'L'] },
   { id: 'usage-meter', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  // Row 2: Cost (M) + Activity Log (M) — spend & health cluster
   { id: 'cost-tracker', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  { id: 'agent-status', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  { id: 'tasks', defaultTier: 'M', allowedTiers: ['M', 'L'] },
-  // Row 4: Sessions + Notifications (large)
+  { id: 'activity-log', defaultTier: 'M', allowedTiers: ['S', 'M'] },
+  // Row 3: System Status (S) + Recent Sessions (L) — status & context
+  { id: 'system-status', defaultTier: 'S', allowedTiers: ['S', 'M'] },
   { id: 'recent-sessions', defaultTier: 'L', allowedTiers: ['L', 'M'] },
-  { id: 'notifications', defaultTier: 'L', allowedTiers: ['L', 'M'] },
-  // Bottom: Weather (nice-to-have)
+  // Row 4: Notifications (M) + Tasks Demo (M)
+  { id: 'notifications', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  { id: 'tasks', defaultTier: 'M', allowedTiers: ['M', 'L'] },
+  // Bottom: Time & Weather (nice-to-have, below fold)
+  { id: 'time-date', defaultTier: 'S', allowedTiers: ['S'] },
   { id: 'weather', defaultTier: 'S', allowedTiers: ['S'] },
 ]
 
@@ -102,7 +103,12 @@ function tierConstraints(tier: WidgetSizeTier, breakpoint: keyof typeof GRID_COL
 }
 
 /* ── Per-Breakpoint Default Layouts ── */
-function buildLayout(breakpoint: keyof typeof GRID_COLS): Layout {
+
+/**
+ * Auto-generate a layout by flowing widgets left-to-right, wrapping rows.
+ * Used for md/sm/xs where manual positioning isn't critical.
+ */
+function buildFlowLayout(breakpoint: keyof typeof GRID_COLS): Layout {
   const cols = GRID_COLS[breakpoint]
   const layouts: LayoutItem[] = []
   let x = 0
@@ -112,24 +118,17 @@ function buildLayout(breakpoint: keyof typeof GRID_COLS): Layout {
   for (const entry of WIDGET_REGISTRY) {
     const dims = tierConstraints(entry.defaultTier, breakpoint)
 
-    // Wrap to next row if widget doesn't fit
     if (x + dims.w > cols) {
       x = 0
       y += rowMaxH
       rowMaxH = 0
     }
 
-    layouts.push({
-      i: entry.id,
-      x,
-      y,
-      ...dims,
-    })
+    layouts.push({ i: entry.id, x, y, ...dims })
 
     rowMaxH = Math.max(rowMaxH, dims.h)
     x += dims.w
 
-    // If we filled the row exactly, advance
     if (x >= cols) {
       x = 0
       y += rowMaxH
@@ -140,11 +139,36 @@ function buildLayout(breakpoint: keyof typeof GRID_COLS): Layout {
   return layouts
 }
 
+/**
+ * Hand-crafted lg (12-col) layout for an intentional default dashboard.
+ * Widgets are placed in a deliberate priority order.
+ */
+function buildLgLayout(): Layout {
+  const c = (_id: WidgetId, tier: WidgetSizeTier) => tierConstraints(tier, 'lg')
+  return [
+    // Row 0: Agents (6 wide) + Usage Meter (6 wide)
+    { i: 'agent-status', x: 0, y: 0, ...c('agent-status', 'M') },
+    { i: 'usage-meter', x: 6, y: 0, ...c('usage-meter', 'M') },
+    // Row 1: Cost Tracker (6 wide) + Activity Log (6 wide)
+    { i: 'cost-tracker', x: 0, y: 5, ...c('cost-tracker', 'M') },
+    { i: 'activity-log', x: 6, y: 5, ...c('activity-log', 'M') },
+    // Row 2: System Status (3 wide) + Recent Sessions (9 = L adjusted)
+    { i: 'system-status', x: 0, y: 10, ...c('system-status', 'S') },
+    { i: 'recent-sessions', x: 3, y: 10, w: 9, h: 5, minW: 6, maxW: 12, minH: 5, maxH: 5 },
+    // Row 3: Notifications (6 wide) + Tasks Demo (6 wide)
+    { i: 'notifications', x: 0, y: 15, ...c('notifications', 'M') },
+    { i: 'tasks', x: 6, y: 15, ...c('tasks', 'M') },
+    // Row 4 (below fold): Time (3) + Weather (3) — compact info strip
+    { i: 'time-date', x: 0, y: 20, ...c('time-date', 'S') },
+    { i: 'weather', x: 3, y: 20, ...c('weather', 'S') },
+  ] as Layout
+}
+
 export const DEFAULT_LAYOUTS: ResponsiveLayouts = {
-  lg: buildLayout('lg'),
-  md: buildLayout('md'),
-  sm: buildLayout('sm'),
-  xs: buildLayout('xs'),
+  lg: buildLgLayout(),
+  md: buildFlowLayout('md'),
+  sm: buildFlowLayout('sm'),
+  xs: buildFlowLayout('xs'),
 }
 
 /* ── Layout Persistence ── */


### PR DESCRIPTION
## Summary
End-to-end dashboard bug bash fixing content overflow, header bloat, and default layout ordering.

## Bugs Fixed
- **BUG-1 (CRITICAL):** Content escaping card boundaries → `DashboardGlassCard` now uses `flex col + overflow-hidden` with scrollable children container
- **BUG-2:** Widget headers too large for S-tier cards → compacted icon (18px), title (sm), description (xs), drag handle (16px)
- **BUG-3:** Default layout not intentional → hand-crafted lg layout with priority ordering
- **BUG-4:** Recent Sessions leaving col gap → widened to 9-col at lg
- **BUG-5:** Drag handle oversized → 16px

## Default Layout Spec (lg/12-col)
| Row | Left | Right |
|-----|------|-------|
| 0 | Active Agents (6) | Usage Meter (6) |
| 1 | Cost Tracker (6) | Activity Log (6) |
| 2 | System Status (3) | Recent Sessions (9) |
| 3 | Notifications (6) | Tasks Demo (6) |
| 4 | Time & Date (3) | Weather (3) |

## Before → After
- ❌ Content bleeding outside cards → ✅ Contained with scroll
- ❌ 80px headers in 210px S-tier cards → ✅ ~60px compact headers
- ❌ Time & Date first, Agents buried → ✅ Agents top, Time/Weather bottom
- ❌ Recent Sessions 8-col with gap → ✅ 9-col fills row

## Build Proof
```
npx vite build → ✓ built in 1.09s (0 errors)
```

## Security Scan
```
grep -rn "apiKey|secret|token|password" src/ → CLEAN
```

## Files Changed (4)
- `dashboard-glass-card.tsx` — overflow containment + compact header
- `grid-config.ts` — widget order + hand-crafted lg layout
- `docs/QA/phase-dashboard-polish-4_TESTPLAN.md` — NEW
- `docs/QA/phase-dashboard-polish-4_RESULTS.md` — NEW

## Manual Test Steps
1. Clear localStorage → hard refresh → verify default layout matches spec
2. Resize browser to md/sm/xs → verify no col overflow
3. Check Cost Tracker & Agent Status → content scrolls, never bleeds
4. Drag a widget → verify persistence after refresh
5. Click Reset Layout → verify default restores

Depends on: PR #10