### PR TITLE
fix: map attachment fields to gateway-expected format

### DIFF
--- a/src/screens/chat/chat-screen.tsx
+++ b/src/screens/chat/chat-screen.tsx
@@ -613,11 +613,10 @@ export function ChatScreen({
     }, 120_000)
 
     const payloadAttachments = normalizedAttachments.map((attachment) => ({
-      id: attachment.id,
-      name: attachment.name,
-      contentType: attachment.contentType,
-      size: attachment.size,
-      dataUrl: attachment.dataUrl,
+      type: 'image',
+      mimeType: attachment.contentType,
+      content: attachment.dataUrl,
+      fileName: attachment.name,
     }))
 
     fetch('/api/send', {


### PR DESCRIPTION
Gateway expects { type, mimeType, content, fileName } but we were sending { id, name, contentType, size, dataUrl }. The gateway's parseMessageWithAttachments() looks for 'mimeType' and 'content' (base64 string), not 'contentType' and 'dataUrl'.