### PR TITLE
Fix model filtering for newer OpenClaw config schema

### DIFF
--- a/src/server/providers.test.ts
+++ b/src/server/providers.test.ts
@@ -1,0 +1,105 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function loadProvidersModule() {
+  vi.resetModules()
+  return import('./providers')
+}
+
+function writeConfig(homeDir: string, config: unknown) {
+  const openclawDir = path.join(homeDir, '.openclaw')
+  fs.mkdirSync(openclawDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(openclawDir, 'openclaw.json'),
+    JSON.stringify(config),
+    'utf8',
+  )
+}
+
+describe('providers config parsing', function suite() {
+  afterEach(function cleanup() {
+    vi.restoreAllMocks()
+  })
+
+  it('parses configured providers from auth profiles', async function test() {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawsuite-test-'))
+    vi.spyOn(os, 'homedir').mockReturnValue(homeDir)
+
+    writeConfig(homeDir, {
+      auth: {
+        profiles: {
+          'anthropic:default': {},
+          'openai-codex:default': {},
+          'github-copilot:work': {},
+        },
+      },
+    })
+
+    const providers = await loadProvidersModule()
+    expect(providers.getConfiguredProviderNames()).toEqual([
+      'anthropic',
+      'github-copilot',
+      'openai-codex',
+    ])
+  })
+
+  it('parses configured model ids from legacy models.providers schema', async function test() {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawsuite-test-'))
+    vi.spyOn(os, 'homedir').mockReturnValue(homeDir)
+
+    writeConfig(homeDir, {
+      models: {
+        providers: {
+          anthropic: {
+            models: [{ id: 'claude-opus-4-6' }, { id: 'claude-sonnet-4-5' }],
+          },
+          'openai-codex': {
+            models: [{ id: 'gpt-5.2' }, { id: 'gpt-5.2-codex' }],
+          },
+        },
+      },
+    })
+
+    const providers = await loadProvidersModule()
+    const modelIds = providers.getConfiguredModelIds()
+    expect(modelIds.has('claude-opus-4-6')).toBe(true)
+    expect(modelIds.has('claude-sonnet-4-5')).toBe(true)
+    expect(modelIds.has('gpt-5.2')).toBe(true)
+    expect(modelIds.has('gpt-5.2-codex')).toBe(true)
+  })
+
+  it('parses configured model ids from agents.defaults schema', async function test() {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawsuite-test-'))
+    vi.spyOn(os, 'homedir').mockReturnValue(homeDir)
+
+    writeConfig(homeDir, {
+      agents: {
+        defaults: {
+          model: {
+            primary: 'anthropic/claude-opus-4-6',
+            fallbacks: [
+              'openai-codex/gpt-5.2',
+              'openai-codex/gpt-5.2-codex',
+              'github-copilot/gpt-5.2-codex',
+            ],
+          },
+          models: {
+            'openai-codex/gpt-5.2': {},
+            'openai-codex/gpt-5.3-codex': {},
+            'github-copilot/gpt-5.2': {},
+            'anthropic/claude-opus-4-6': { alias: 'opus' },
+          },
+        },
+      },
+    })
+
+    const providers = await loadProvidersModule()
+    const modelIds = providers.getConfiguredModelIds()
+    expect(modelIds.has('claude-opus-4-6')).toBe(true)
+    expect(modelIds.has('gpt-5.2')).toBe(true)
+    expect(modelIds.has('gpt-5.2-codex')).toBe(true)
+    expect(modelIds.has('gpt-5.3-codex')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
Fixes provider model counts showing `0` for configured providers (notably `openai-codex`) when OpenClaw uses the newer config schema under `agents.defaults`.

## Problem
`/api/models` filters gateway models by configured provider + configured model IDs.
`getConfiguredModelIds()` only read legacy IDs from:
- `models.providers.<provider>.models[].id`

On newer OpenClaw setups, configured model selections are stored in:
- `agents.defaults.models["provider/model-id"]`
- `agents.defaults.model.primary`
- `agents.defaults.model.fallbacks[]`

Result: provider appears configured but model count incorrectly becomes `0`.

## Fix
Updated `src/server/providers.ts`:
- Added support for `agents.defaults.models` keys (`provider/model-id` -> `model-id`)
- Added support for `agents.defaults.model.primary` and `fallbacks`
- Kept legacy `models.providers.*.models[].id` support for backward compatibility

## Tests
Added `src/server/providers.test.ts` with coverage for:
- configured providers from `auth.profiles`
- legacy model IDs from `models.providers`
- current model IDs from `agents.defaults` (including primary + fallbacks)

## Validation
- Confirmed `/api/models` now returns `openai-codex` models where previously none were returned.
- Ran tests in a Node 25 environment:
  - `npm test -- src/server/providers.test.ts src/server/usage-cost.test.ts`
  - Result: `5 passed (5)`

## Notes
Local Node 21 cannot run this repo’s test stack reliably (requires newer Node), so test execution was validated on a compatible host.
