### PR TITLE
fix: default theme to 'system' instead of 'light'

### DIFF
--- a/src/hooks/use-settings.ts
+++ b/src/hooks/use-settings.ts
@@ -29,7 +29,7 @@ type SettingsState = {
 export const defaultStudioSettings: StudioSettings = {
   gatewayUrl: '',
   gatewayToken: '',
-  theme: 'light',
+  theme: 'system',
   accentColor: 'orange',
   editorFontSize: 13,
   editorWordWrap: true,


### PR DESCRIPTION
## Problem
New users or users with cleared localStorage always start in light mode regardless of their OS preference.

## Change
Changed `defaultStudioSettings.theme` from `'light'` to `'system'` in `src/hooks/use-settings.ts`.

This respects the user's OS dark/light mode preference out of the box. The inline `themeScript` in `__root.tsx` already handles resolving `'system'` via `matchMedia('(prefers-color-scheme: dark)')`, so no other changes needed.

Relates to #22